### PR TITLE
Sync Firestore indexes from remote

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,4 +1,35 @@
 {
-  "indexes": [],
+  "indexes": [
+    {
+      "collectionGroup": "recipes",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "createdBy",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "name",
+          "order": "ASCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
+    },
+    {
+      "collectionGroup": "recipes",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "slug",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "name",
+          "order": "ASCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
+    }
+  ],
   "fieldOverrides": []
 }


### PR DESCRIPTION
This pull request adds two new composite indexes to the Firestore configuration for the `recipes` collection. These indexes are designed to improve query performance when filtering or sorting recipes by specific fields.

**Firestore index enhancements:**

* Added a composite index on the `recipes` collection for the `createdBy` and `name` fields to support efficient queries that filter or sort by these fields.
* Added a composite index on the `recipes` collection for the `slug` and `name` fields to optimize queries involving these fields.